### PR TITLE
Added option to pass auth ID into __contructor function.

### DIFF
--- a/templates/abstract.tpl.php
+++ b/templates/abstract.tpl.php
@@ -142,10 +142,11 @@ abstract class <CLASSNAME_ABSTRACT>
     {
         if($apiUrl)
             $this->setApiUrl($apiUrl);
-        if (!$authId) {
-            if ($httpUser && $httpPassword)
+
+        if ($httpUser && $httpPassword)
                 $this->setBasicAuthorization($httpUser, $httpPassword);
 
+        if (!$authId) {
             if($user && $password)
                 $this->userLogin(array('user' => $user, 'password' => $password));
         }

--- a/templates/abstract.tpl.php
+++ b/templates/abstract.tpl.php
@@ -142,7 +142,7 @@ abstract class <CLASSNAME_ABSTRACT>
     {
         if($apiUrl)
             $this->setApiUrl($apiUrl);
-        if (!authId) {
+        if (!$authId) {
             if ($httpUser && $httpPassword)
                 $this->setBasicAuthorization($httpUser, $httpPassword);
 

--- a/templates/abstract.tpl.php
+++ b/templates/abstract.tpl.php
@@ -135,18 +135,22 @@ abstract class <CLASSNAME_ABSTRACT>
      * @param   $password       Password for Zabbix API.
      * @param   $httpUser       Username for HTTP basic authorization.
      * @param   $httpPassword   Password for HTTP basic authorization.
+     * @param   $authId         Already issued auth (e.g. extracted from cookies)
      */
 
-    public function __construct($apiUrl='', $user='', $password='', $httpUser='', $httpPassword='')
+    public function __construct($apiUrl='', $user='', $password='', $httpUser='', $httpPassword='', $authId='')
     {
         if($apiUrl)
             $this->setApiUrl($apiUrl);
+        if (!authId) {
+            if ($httpUser && $httpPassword)
+                $this->setBasicAuthorization($httpUser, $httpPassword);
 
-        if ($httpUser && $httpPassword)
-            $this->setBasicAuthorization($httpUser, $httpPassword);
-
-        if($user && $password)
-            $this->userLogin(array('user' => $user, 'password' => $password));
+            if($user && $password)
+                $this->userLogin(array('user' => $user, 'password' => $password));
+        }
+        else
+            $this->auth=$authId;
     }
 
     /**


### PR DESCRIPTION
This lets users that are already logged in into web interface, to use auth id from cookies (zbx_sessionid) with the API, instead of logging in again.
e.g.:
     $zbx_sessionid=$_COOKIE['zbx_sessionid'];
     $api = new ZabbixApi('http://192.168.119.130/zabbix/api_jsonrpc.php','','','','',$zbx_sessionid);